### PR TITLE
Implement protection against breaking changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,28 +88,16 @@ fn check(default_extractor: &VersionExtractor) -> Result<()> {
     let lines: std::result::Result<Vec<String>, io::Error> = stdin.lock().lines().collect();
     let lines = lines?;
 
-    let amount = 25;
-    let result = extract(lines, amount, &default_extractor)?;
-
-    let output: Vec<String> = result
+    let result: Result<Vec<Option<String>>> = lines
         .into_iter()
-        .map(|(maybe_tag, statement)| match maybe_tag {
-            Some(tag) => format!(
-                "Current: `{}:{}`. Newest matching tag: `{}`.",
-                statement.image, statement.tag, tag
-            ),
-            None => {
-                let pattern = match statement.extractor {
-                    Some(extractor) => extractor.to_string(),
-                    None => default_extractor.to_string(),
-                };
-                format!(
-                    "Current: `{}:{}`. No tag matching `{}` found. (Searched latest {} tags.)",
-                    statement.image, statement.tag, pattern, amount
-                )
-            }
+        .map(|line| {
+            Ok(FromStatement::extract_from(line)?
+                .map(|statement| check_statement(&statement, default_extractor))
+                .transpose()?)
         })
         .collect();
+    let output: Vec<String> = result?.into_iter().filter_map(|s| s).collect();
+
     println!(
         "Found {} parent images:\n{}",
         output.len(),
@@ -119,96 +107,100 @@ fn check(default_extractor: &VersionExtractor) -> Result<()> {
     Ok(())
 }
 
+fn check_statement(
+    statement: &FromStatement,
+    default_extractor: &VersionExtractor,
+) -> Result<String> {
+    let amount = 25;
+    let tags = DockerHubTagFetcher::fetch(
+        &statement.image,
+        &Page {
+            size: amount,
+            page: 1,
+        },
+    )?;
+    let newest = match &statement.extractor {
+        Some(extractor) => extractor.max(tags)?,
+        None => default_extractor.max(tags)?,
+    };
+    let output = match newest {
+        Some(tag) => format!(
+            "Current: `{}:{}`. Newest matching tag: `{}`.",
+            statement.image, statement.tag, tag
+        ),
+        None => {
+            let pattern = match &statement.extractor {
+                Some(extractor) => extractor.to_string(),
+                None => default_extractor.to_string(),
+            };
+            format!(
+                "Current: `{}:{}`. No tag matching `{}` found. (Searched latest {} tags.)",
+                statement.image, statement.tag, pattern, amount
+            )
+        }
+    };
+    Ok(output)
+}
+
 fn upgrade(dockerfile: PathBuf, default_extractor: VersionExtractor) -> Result<()> {
     let input = std::fs::read_to_string(&dockerfile)?;
 
-    let amount = 25;
-    let output = map_extraction(
-        input.lines(),
-        amount,
-        &default_extractor,
-        |line, maybe_extraction| match maybe_extraction {
-            None => line,
-            Some(extraction) => match extraction.newest_tag {
-                None => {
-                    let pattern = match &extraction.statement.extractor {
-                        Some(extractor) => format!("{}", extractor),
-                        None => format!("{}", default_extractor),
-                    };
-                    eprintln!("Could not find any tag for image {} matching `{}`. (Searched the latest {} tags.) Current tag `{}` will be kept.", extraction.statement.image,pattern, amount, extraction.statement.tag);
-                    format!("{}", extraction.statement)
-                }
-                Some(update) => {
-                    let mut statement = extraction.statement;
-                    println!(
-                        "Upgrading image {} from `{}` to `{}`.",
-                        statement.image, statement.tag, update
-                    );
-                    statement.tag = update;
-                    format!("{}", statement)
-                }
-            },
-        },
-    )?;
+    let result: Result<Vec<String>> = input
+        .lines()
+        .map(|line| {
+            Ok(FromStatement::extract_from(&line)?
+                .map(|mut statement| process_statement(&mut statement, &default_extractor))
+                .transpose()?
+                .unwrap_or_else(|| line.to_string()))
+        })
+        .collect();
+    let output: Vec<String> = result?;
 
     std::fs::write(&dockerfile, output.join("\n"))?;
 
     Ok(())
 }
 
-struct ExtractionFromStatement {
-    statement: FromStatement,
-    newest_tag: Option<String>,
-}
-
-fn extract(
-    lines: impl IntoIterator<Item = impl AsRef<str>>,
-    amount: u32,
+fn process_statement(
+    mut statement: &mut FromStatement,
     default_extractor: &VersionExtractor,
-) -> Result<Vec<(Option<String>, FromStatement)>> {
-    Ok(
-        map_extraction(lines, amount, default_extractor, |_, maybe_extraction| {
-            maybe_extraction.map(|extraction| (extraction.newest_tag, extraction.statement))
-        })?
-        .into_iter()
-        .filter_map(|statement| statement)
-        .collect(),
-    )
-}
-
-fn map_extraction<T>(
-    lines: impl IntoIterator<Item = impl AsRef<str>>,
-    amount: u32,
-    default_extractor: &VersionExtractor,
-    mut process: impl FnMut(String, Option<ExtractionFromStatement>) -> T,
-) -> Result<Vec<T>> {
-    lines
-        .into_iter()
-        .map(|line| {
-            let extracted: Result<Option<ExtractionFromStatement>> =
-                FromStatement::extract_from(&line)?
-                    .map(|statement| {
-                        let tags = DockerHubTagFetcher::fetch(
-                            &statement.image,
-                            &Page {
-                                size: amount,
-                                page: 1,
-                            },
-                        )?;
-
-                        let newest_tag = match &statement.extractor {
-                            Some(extractor) => extractor.max(tags)?,
-                            None => default_extractor.max(tags)?,
-                        };
-                        Ok(ExtractionFromStatement {
-                            statement,
-                            newest_tag,
-                        })
-                    })
-                    .transpose();
-            Ok(process(line.as_ref().to_string(), extracted?))
-        })
-        .collect()
+) -> Result<String> {
+    let amount = 25;
+    let tags = DockerHubTagFetcher::fetch(
+        &statement.image,
+        &Page {
+            size: amount,
+            page: 1,
+        },
+    )?;
+    let extractor = statement.extractor.as_ref().unwrap_or(default_extractor);
+    let newest = extractor.max(tags)?;
+    let output = match newest {
+        None => {
+            let pattern = format!("{}", extractor);
+            eprintln!("The latest {} tags for image {} did not contain any match for `{}`. Current tag `{}` will be kept.", statement.image,pattern, amount, statement.tag);
+            format!("{}", statement)
+        }
+        Some(update) => {
+            let current = extractor.extract_from(&statement.tag).unwrap().unwrap();
+            let next = extractor.extract_from(&update).unwrap().unwrap();
+            if current.should_upgrade_to(next, statement.breaking_degree) {
+                println!(
+                    "Upgrading image {} from `{}` to `{}`.",
+                    statement.image, statement.tag, update
+                );
+                statement.tag = update;
+                format!("{}", statement)
+            } else {
+                println!(
+                    "Image {} has a breaking upgrade from `{}` to `{}`. Will keep current tag (`{1}`).",
+                    statement.image, statement.tag, update
+                );
+                format!("{}", statement)
+            }
+        }
+    };
+    Ok(output)
 }
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;

--- a/src/version_extractor.rs
+++ b/src/version_extractor.rs
@@ -45,7 +45,7 @@ use regex::Regex;
 /// [unnamed capture groups]: https://docs.rs/regex/1.3.1/regex/#grouping-and-flags
 /// [Regex]: https://docs.rs/regex/1.3.1/regex/index.html#syntax
 /// [`extract_from()`]: #method.extract_from
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VersionExtractor {
     regex: Regex,
 }


### PR DESCRIPTION
Upgrading the version should not be automatically when that entails breaking changes, as e. g. specified by SemVer. updock should understand these limits and not automatically upgrade the image.